### PR TITLE
Set documentation to docs.rs and remove homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.2.0"
 authors = ["Colin Sherratt <colin.sherratt@gmail.com>"]
 license = "Apache-2.0/MIT"
 description = "A set of utilities to enable higher level operations over tuples."
-documentation = "http://csherratt.github.io/tuple_utils"
-homepage = "https://github.com/csherratt/tuple_utils"
+documentation = "https://docs.rs/tuple_utils"
 repository = "https://github.com/csherratt/tuple_utils"
 


### PR DESCRIPTION
Hi there! Just some metadata change for the next release :)

---

The old GitHub pages URL for the documentation didn't work anymore and using 
documentation on docs.rs has become the status quo. 

The `homepage` field shouldn't point to the repository, that's what the 
repository field is for. `homepage` should only be used for non-repository
pages.